### PR TITLE
fix the sample video play icon on the home page.

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -244,6 +244,7 @@
   font-size: 3rem;
   transition: var(--themeTransition);
   color: rgb(var(--secondaryColor));
+  position: absolute;
 }
 
 .sample_video .sample_video__image:hover span {


### PR DESCRIPTION
The video play icon was constantly hiding under text o some screens so the best way was to give it an absolute position such that it follows the parent positioning